### PR TITLE
#50: Fehlende Details, bei den Zutaten

### DIFF
--- a/src/components/QuantityCalculation/quantityCalculationPdf.jsx
+++ b/src/components/QuantityCalculation/quantityCalculationPdf.jsx
@@ -190,25 +190,30 @@ const RecipeIngredients = ({ mealRecipe }) => {
           </View>
         </View>
         <View style={styles.tableRow}>
-          <View style={styles.tableCol50}>
-            <Text style={styles.tableCellBold}>{TEXT.ORIGINAL_QUANTITIES}</Text>
+          <View style={styles.tableCol25}>
+            <Text style={{ ...styles.tableCellBold, ...styles.tableCellGrey }}>
+              {TEXT.ORIGINAL_QUANTITIES}
+            </Text>
           </View>
-          <View style={styles.tableCol50}>
+          <View style={styles.tableCol25}>
             <Text style={styles.tableCellBold}>{TEXT.SCALED_QUANTITIES}</Text>
           </View>
+          <View style={styles.tableCol50} />
         </View>
         <View style={styles.tableRow}>
-          <View style={styles.tableCol50}>
-            <Text style={styles.tableCell}>
+          <View style={styles.tableCol25}>
+            <Text style={{ ...styles.tableCell, ...styles.tableCellGrey }}>
               {mealRecipe.recipe.portions} {TEXT.FIELD_PORTIONS}
             </Text>
           </View>
-          <View style={styles.tableCol50}>
+          <View style={styles.tableCol25}>
             <Text style={styles.tableCell}>
               {mealRecipe.recipe.scaledNoOfServings} {TEXT.FIELD_PORTIONS}
             </Text>
           </View>
+          <View style={styles.tableCol50} />
         </View>
+
         {/* Leerzeile */}
         <View style={styles.tableRow}>
           <View style={styles.tableCol100}>
@@ -229,7 +234,12 @@ const RecipeIngredients = ({ mealRecipe }) => {
                   "ingredientQuantity_Left_" + mealRecipe.uid + "_" + counter
                 }
               >
-                <Text style={styles.tableCell}>
+                <Text
+                  style={{
+                    ...styles.tableCell,
+                    ...styles.tableCellGrey,
+                  }}
+                >
                   {Number.isNaN(ingredient.quantity)
                     ? ""
                     : ingredient.quantity.toLocaleString("de-CH")}
@@ -239,13 +249,9 @@ const RecipeIngredients = ({ mealRecipe }) => {
                 style={styles.tableColUnit}
                 key={"ingredientUnit_Left_" + mealRecipe.uid + "_" + counter}
               >
-                <Text style={styles.tableCell}>{ingredient.unit}</Text>
-              </View>
-              <View
-                style={styles.tableColItem}
-                key={"ingredientProduct_Left_" + mealRecipe.uid + "_" + counter}
-              >
-                <Text style={styles.tableCell}>{ingredient.product.name}</Text>
+                <Text style={{ ...styles.tableCell, ...styles.tableCellGrey }}>
+                  {ingredient.unit}
+                </Text>
               </View>
               <View
                 style={styles.tableColQuantity}
@@ -279,6 +285,12 @@ const RecipeIngredients = ({ mealRecipe }) => {
               >
                 <Text style={styles.tableCell}>
                   {mealRecipe.recipe.scaledIngredients[counter].product.name}
+                  {/* Details abdrucken, falls vorhanden */}
+                  {mealRecipe.recipe.scaledIngredients[counter].detail && (
+                    <Text style={styles.tableCellThin}>
+                      , {mealRecipe.recipe.scaledIngredients[counter].detail}
+                    </Text>
+                  )}
                 </Text>
               </View>
             </View>

--- a/src/constants/stylesPdf.js
+++ b/src/constants/stylesPdf.js
@@ -1,3 +1,4 @@
+import { red } from "@material-ui/core/colors";
 import { StyleSheet } from "@react-pdf/renderer";
 
 export default class PdfStyles {
@@ -177,16 +178,28 @@ export default class PdfStyles {
         width: "20%",
         textAlign: "center",
       },
+      tableCol25: {
+        width: "25%",
+        textAlign: "center",
+      },
+      tableCol75: {
+        width: "75%",
+        textAlign: "center",
+      },
+      tableCol80: {
+        width: "80%",
+        textAlign: "center",
+      },
       tableColQuantity: {
         width: "10%",
         textAlign: "right",
       },
       tableColUnit: {
-        width: "10%",
+        width: "7%",
         textAlign: "left",
       },
       tableColItem: {
-        width: "30%",
+        width: "60%",
         textAlign: "left",
       },
       tableColStepPos: {
@@ -246,6 +259,12 @@ export default class PdfStyles {
       },
       tableCellGrey: {
         color: "grey",
+      },
+      tableCellThin: {
+        fontSize: 11,
+        fontFamily: "Roboto",
+        fontStyle: "thin",
+        fontWeight: 100,
       },
       tableCellBold: {
         margin: 3,


### PR DESCRIPTION
Bei dem PDF Export der Mengenberechnung, werden die Details zu den Zutaten nicht angezeigt. Diese wurde behoben. Dadurch musste auch das Layout des PDF minim angepasst werden.

close #50 