### PR TITLE
Korrektur der Anzahl Zeilen für den PDF Export

### DIFF
--- a/src/components/ShoppingList/shoppingListPdf.jsx
+++ b/src/components/ShoppingList/shoppingListPdf.jsx
@@ -19,7 +19,7 @@ import * as IMAGE_REPOSITORY from "../../constants/imageRepository";
 // Anzahl Zeilen, die pro Seite platz haben
 const LINES_PER_PAGE = {
   FIRST: 33,
-  REST: 38,
+  REST: 35,
 };
 
 const COLUMN = {


### PR DESCRIPTION
Für alle Seiten (ausser die erste) wurden die Anzahl anzuzeigende Zeilen korrigiert.

close #102 