### PR TITLE
Speichern Button auch am Ende des Rezeptes

### DIFF
--- a/src/components/Recipe/recipe.class.js
+++ b/src/components/Recipe/recipe.class.js
@@ -534,6 +534,9 @@ export default class Recipe {
         if (recipe.preparationSteps.length === 0) {
           recipe.preparationSteps.push(Recipe.createEmptyPreparationStep());
         }
+        if (!recipe.private) {
+          recipe.private = false;
+        }
       })
       .then(async () => {
         // Bewertung holen

--- a/src/components/Recipe/recipe.jsx
+++ b/src/components/Recipe/recipe.jsx
@@ -812,7 +812,7 @@ const RecipeBase = ({ props, authUser }) => {
   /* ------------------------------------------
   // Rezept speichern
   // ------------------------------------------ */
-  const onSaveClick = async (authUser) => {
+  const onSaveClick = async () => {
     try {
       Recipe.checkRecipeData(recipe.data);
     } catch (error) {
@@ -1500,6 +1500,32 @@ const RecipeBase = ({ props, authUser }) => {
                 onLoadPrevious={onLoadPreviousComments}
               />
             </Grid>
+          )}
+          {editMode && (
+            // Speicherbuttons nochmals anzeigen
+            <ButtonRow
+              key="buttons_save_bottom"
+              buttons={[
+                {
+                  id: "save",
+                  hero: true,
+                  label: TEXT.BUTTON_SAVE,
+                  variant: "contained",
+                  color: "primary",
+                  visible: true,
+                  onClick: onSaveClick,
+                },
+                {
+                  id: "cancel",
+                  hero: true,
+                  label: TEXT.BUTTON_CANCEL,
+                  variant: "outlined",
+                  color: "primary",
+                  visible: true,
+                  onClick: onCancelClick,
+                },
+              ]}
+            />
           )}
         </Grid>
       </Container>


### PR DESCRIPTION
Damit beim Bearbeiten/Erfassen des Rezeptes am Schluss einfach gespeichert werden kann, wurden die Speichern/Abbrechen-Buttons auch am Ende des Rezeptes eingefügt.
Zudem kleine Korrektur in der Rezeptklasse. Wenn das Feld _private_ nicht vorhanden ist, wird es beim Lesen des Rezeptes mit dem wert **false** der aufrufenden Methode übergeben.

close #112 