### PR TITLE
Zutaten-Dropdown nach Eingabe sortieren

### DIFF
--- a/src/components/Recipe/recipe.jsx
+++ b/src/components/Recipe/recipe.jsx
@@ -2445,7 +2445,8 @@ const IngredientPosition = ({
               }
               fullWidth
               filterOptions={(options, params) => {
-                const filtered = filter(options, params);
+                let filtered = filter(options, params);
+
                 if (
                   params.inputValue !== "" &&
                   // Sicherstellen, dass kein Produkt mit gleichem Namen erfasst wird
@@ -2460,6 +2461,33 @@ const IngredientPosition = ({
                     name: `"${params.inputValue}" ${TEXT.ADD}`,
                   });
                 }
+
+                // So sortieren, dass Zutaten, die mit den gleichen Zeichen beginnen
+                // vorher angezeigt werden (Salz vor Erdnüsse, gesalzen)
+                filtered = filtered.map((entry) => {
+                  let sortRank;
+
+                  if (entry?.inputValue) {
+                    sortRank = 100;
+                  } else if (
+                    entry.name
+                      .substr(0, params.inputValue.length)
+                      .toLowerCase() === params.inputValue.toLowerCase()
+                  ) {
+                    sortRank = 1;
+                  } else {
+                    sortRank = 10;
+                  }
+
+                  return { ...entry, ...{ sortRank: sortRank } };
+                });
+
+                filtered = Utils.sortArrayWithObjectByNumber({
+                  list: filtered,
+                  attributeName: "sortRank",
+                });
+
+                filtered.forEach((entry) => delete entry.sortRank);
                 return filtered;
               }}
               renderOption={(option) => option.name}

--- a/src/components/ShoppingList/dialogShoppingListItem.jsx
+++ b/src/components/ShoppingList/dialogShoppingListItem.jsx
@@ -22,6 +22,7 @@ import useStyles from "../../constants/styles";
 import * as TEXT from "../../constants/text";
 
 import CustomSnackbar from "../Shared/customSnackbar";
+import Utils from "../Shared/utils.class";
 
 import DialogProduct, {
   PRODUCT_POP_UP_VALUES_INITIAL_STATE,
@@ -289,7 +290,7 @@ const DialogShoppingListItem = ({
               onChange={onFieldChange}
               fullWidth
               filterOptions={(options, params) => {
-                const filtered = filter(options, params);
+                let filtered = filter(options, params);
                 if (
                   params.inputValue !== "" &&
                   // Sicherstellen, dass kein Produkt mit gleichem Namen erfasst wird
@@ -304,6 +305,32 @@ const DialogShoppingListItem = ({
                     name: `"${params.inputValue}" ${TEXT.ADD}`,
                   });
                 }
+                // So sortieren, dass Zutaten, die mit den gleichen Zeichen beginnen
+                // vorher angezeigt werden (Salz vor Erdnüsse, gesalzen)
+                filtered = filtered.map((entry) => {
+                  let sortRank;
+
+                  if (entry?.inputValue) {
+                    sortRank = 100;
+                  } else if (
+                    entry.name
+                      .substr(0, params.inputValue.length)
+                      .toLowerCase() === params.inputValue.toLowerCase()
+                  ) {
+                    sortRank = 1;
+                  } else {
+                    sortRank = 10;
+                  }
+
+                  return { ...entry, ...{ sortRank: sortRank } };
+                });
+
+                filtered = Utils.sortArrayWithObjectByNumber({
+                  list: filtered,
+                  attributeName: "sortRank",
+                });
+
+                filtered.forEach((entry) => delete entry.sortRank);
                 return filtered;
               }}
               renderOption={(option) => option.name}


### PR DESCRIPTION
Das Zutaten/Produkt-Dropdown sortiert die Einträge nach der Eingabe und nicht nur Alfabetisch. Bei der Eingabe "Sal" wird nun der Eintrag "Salz" vor dem Eintrag "Erdnüsse, gesalzen" angezeigt, da davon ausgegangen werden kann, dass eher der Eintrag Salz gesucht wird (beginnt mit den gleichen Buchstaben).

close #122 