### PR TITLE
Anpassung der Analytics-Events

### DIFF
--- a/src/components/Event/Event/event.tsx
+++ b/src/components/Event/Event/event.tsx
@@ -1030,18 +1030,13 @@ const EventBase: React.FC<
     const menuplan = Menuplan.recalculatePortions({
       menuplan: state.menuplan,
       groupConfig: groupConfiguration,
+      firebase: firebase,
     });
 
     // neuer Menüplan speichern
     onMenuplanUpdate(menuplan);
 
     // Kein zurückschreiben in den State, da der Listener, das wieder erhält....
-
-    // // neue GroupConfig in State aufnehmen
-    // dispatch({
-    //   type: ReducerActions.GROUP_CONFIG_FETCH_SUCCESS,
-    //   payload: groupConfiguration,
-    // });
   };
   const onShoppingListUpdate = (shoppingList: ShoppingList) => {
     ShoppingList.save({

--- a/src/components/Event/Menuplan/menuplan.class.ts
+++ b/src/components/Event/Menuplan/menuplan.class.ts
@@ -14,6 +14,7 @@ import EventGroupConfiguration, {
 import RecipeShort from "../../Recipe/recipeShort.class";
 import Unit from "../../Unit/unit.class";
 import _ from "lodash";
+import FirebaseAnalyticEvent from "../../../constants/firebaseEvent";
 interface MenuplanObjectStructure<T> {
   entries: {[key: string]: T};
   order: string[];
@@ -210,6 +211,7 @@ interface AddPlanToGood<T> {
 }
 
 interface RecalculatePortions {
+  firebase: Firebase;
   menuplan: Menuplan;
   groupConfig: EventGroupConfiguration;
 }
@@ -729,6 +731,7 @@ export default class Menuplan {
    * @returns Menuüplan
    */
   static recalculatePortions = ({
+    firebase,
     menuplan,
     groupConfig,
   }: RecalculatePortions) => {
@@ -808,6 +811,11 @@ export default class Menuplan {
         (plan) => plan.diet != "" && plan.intolerance != ""
       );
     });
+
+    // Analytics mitführen
+    firebase.analytics.logEvent(
+      FirebaseAnalyticEvent.eventGroupConifgRecalculated
+    );
 
     return menuplan;
   };

--- a/src/constants/firebaseEvent.ts
+++ b/src/constants/firebaseEvent.ts
@@ -13,6 +13,7 @@ export enum FirebaseAnalyticEvent {
   eventGetHistory = "event_get_history",
   eventCookAdded = "event_cook_added",
   eventCookRemoved = "event_cook_removed",
+  eventGroupConifgRecalculated = "event_groupConfig_recalculated",
   userCreated = "user_created",
   userChangedEmail = "user_changed_email",
   userChangedPassword = "user_changed_password",


### PR DESCRIPTION
Struktur war bereits so vorhanden. Nun wurde der Analytics-Event hinzugefügt, wenn eine Group-Config neu berechnet wird. 