### PR TITLE
Add null check to material.quantity

### DIFF
--- a/src/components/Recipe/recipe.view.tsx
+++ b/src/components/Recipe/recipe.view.tsx
@@ -2100,7 +2100,8 @@ export const RecipeMaterial = ({
                     key={"material_quantity_original_" + materialUid}
                     color="textSecondary"
                   >
-                    {Number.isNaN(material.quantity) || material.quantity == 0
+                    {Number.isNaN(material.quantity) || material.quantity == 0 ||
+                      material.quantity == null
                       ? ""
                       : material.quantity.toLocaleString("de-CH")}
                   </Typography>
@@ -2127,7 +2128,7 @@ export const RecipeMaterial = ({
                           "de-CH"
                         )
                     : Number.isNaN(material?.quantity) ||
-                      material?.quantity == 0
+                      material?.quantity == 0  || material?.quantity == null
                     ? ""
                     : material?.quantity.toLocaleString("de-CH")}
                 </Typography>


### PR DESCRIPTION
Fix following bug

**Description**: Detailseite von Rezept wird nicht angezeigt, sondern weisse Seite ohne Inhalt.

**Steps to reproduce**:

1. Benutzerdefinierten Rezept erstellen
2. Material hinzufügen mit einer Menge, z.b. 1 Stück
3. "Speichern" klicken
4. Rezept zu Anlass hinzufügen
5. Rezept wieder öffnen
6. "Anpassen" klicken
7. Beim vorher hinzugefügten Material die Menge rauslöschen (Inputfeld leer)
8. "Speichern" klicken

**Erwartetes Resultat ohne Fehler**: Detailseite von Rezept wird angezeigt.

**Betriebssystem**: Windows 11
**Browser**: Google Chrome Version 128.0.6613.120 (Offizieller Build) (64-Bit)