### PR TITLE
fix: PROD-App-Container wird nicht automatisch erstellt, falls er fehlt

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -211,6 +211,16 @@ jobs:
           target: "/opt/chuchipirat/prod/app/html/"
           strip_components: 1
 
+      - name: Copy Docker Compose file for App to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: "infra/app/docker-compose.prod.yml"
+          target: "/tmp/chuchipirat-deploy/"
+          strip_components: 2
+
       - name: Copy nginx config to server
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -221,26 +231,23 @@ jobs:
           target: "/tmp/chuchipirat-deploy/"
           strip_components: 2
 
-      - name: Move nginx config to app directory
+      - name: Deploy App Container
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
+            cp /tmp/chuchipirat-deploy/docker-compose.prod.yml /opt/chuchipirat/prod/app/docker-compose.yml
             cp /tmp/chuchipirat-deploy/nginx.prod.conf /opt/chuchipirat/prod/app/nginx.conf
             rm -rf /tmp/chuchipirat-deploy/
-            docker restart chuchipirat-app-prod
-            sleep 3
-            docker ps | grep chuchipirat-app-prod
-
-      - name: Restart App Container
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: |
+            # "docker compose up" erstellt den App-Container, falls er (z.B. beim
+            # allerersten Deploy oder nach manuellem Entfernen) noch nicht
+            # existiert - bei einem bereits laufenden, unveränderten Container
+            # ist es ein No-Op. Der anschliessende restart sorgt dafür, dass
+            # nginx die neu kopierten Bind-Mount-Dateien (html/, nginx.conf)
+            # einliest.
+            cd /opt/chuchipirat/prod/app && docker compose up -d
             docker restart chuchipirat-app-prod
             sleep 3
             docker ps | grep chuchipirat-app-prod


### PR DESCRIPTION
"docker restart" schlägt fehl, wenn der Container noch nie existiert hat (z.B. beim allerersten PROD-Deploy oder nach manuellem Entfernen) - genau das ist gerade beim ersten Merge nach main passiert. "docker compose up -d" vor dem restart erstellt den Container bei Bedarf, ist bei einem bereits laufenden, unveränderten Container aber ein No-Op. Analog zum bereits selbstheilenden edge-functions-Schritt. Dabei auch zwei redundante "docker restart"-Schritte zu einem zusammengefasst.
