### PR TITLE
fix: Release-Workflow scheitert mit 403, da GITHUB_TOKEN keine Schrei…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     # Nur wenn Deploy PROD erfolgreich war
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # workflow_run-getriggerte Workflows erhalten standardmässig nur ein
+    # read-only GITHUB_TOKEN - ohne dies schlägt "gh release create" mit
+    # 403 fehl.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
…brechte hat

workflow_run-getriggerte Workflows erhalten standardmässig nur ein read-only GITHUB_TOKEN. "gh release create" schlug deshalb nach jedem erfolgreichen Deploy PROD mit Exit-Code 1 fehl (bestätigt in Run 32476390164, ausgelöst durch den letzten main-Merge) - es wurde nie ein Tag/Release erstellt, obwohl die Version schon auf 2.0.0 stand.