### PR TITLE
fix: E-Mailadressenwechsel und UX Verbesserungen

### DIFF
--- a/src/components/Admin/MigrationJobs/MenuplanMigrationJob.ts
+++ b/src/components/Admin/MigrationJobs/MenuplanMigrationJob.ts
@@ -197,17 +197,42 @@ const normalizeDateToLocalYmd = (value: unknown): string | null => {
 };
 
 /**
+ * Maximal zulässiger Betrag für Spalten vom Typ NUMERIC(10,2)/NUMERIC(12,4)
+ * (z.B. total_portions, quantity, total_quantity, servings) — Postgres
+ * akzeptiert bei dieser Präzision/Skalierung nur Werte < 10^8.
+ */
+const MAX_QUANTITY_VALUE = 99_999_999;
+
+/**
+ * Maximal zulässiger Betrag für die Spalte event_menuplan_item_plans.factor
+ * (NUMERIC(10,4)) — Postgres akzeptiert bei dieser Präzision/Skalierung nur
+ * Werte < 10^6.
+ */
+const MAX_FACTOR_VALUE = 999_999;
+
+/**
  * Gibt einen sicheren numerischen Wert zurück. Fängt leere Strings,
- * NaN, Infinity und null/undefined ab.
+ * NaN, Infinity und null/undefined ab. Ist `maxAbsValue` gesetzt, wird der
+ * Betrag zusätzlich auf diesen Wert begrenzt (statt die gesamte Zeile durch
+ * einen NUMERIC-Overflow scheitern zu lassen) — Fehleingaben/Fake-Werte aus
+ * Firebase (z.B. Portionen: 100000000) dürfen nicht den kompletten
+ * Batch-Insert eines Menüplans zerstören.
  *
  * @param value - Wert aus Firebase (kann String, Zahl oder undefined sein)
  * @param fallback - Rückgabewert bei ungültigem Input (Standard: 0)
- * @returns Gültiger numerischer Wert
+ * @param maxAbsValue - Maximal zulässiger Betrag (optional, kein Limit falls nicht gesetzt)
+ * @returns Gültiger, ggf. begrenzter numerischer Wert
  */
-const safeNumber = (value: unknown, fallback = 0): number => {
+const safeNumber = (
+  value: unknown,
+  fallback = 0,
+  maxAbsValue?: number,
+): number => {
   if (value === undefined || value === null || value === "") return fallback;
   const num = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(num) ? num : fallback;
+  if (!Number.isFinite(num)) return fallback;
+  if (maxAbsValue === undefined) return num;
+  return Math.max(-maxAbsValue, Math.min(maxAbsValue, num));
 };
 
 
@@ -551,7 +576,7 @@ export class MenuplanMigrationJob implements MigrationJob<FirebaseMenuplanData> 
         recipe_id: recipeId,
         deleted_recipe_name: deletedRecipeName,
         variant_name: mealRecipe.recipe.variantName ?? null,
-        total_portions: safeNumber(mealRecipe.totalPortions),
+        total_portions: safeNumber(mealRecipe.totalPortions, 0, MAX_QUANTITY_VALUE),
         sort_order: recipeOrderInMenue.get(recipeFirebaseUid) ?? 0,
         firebase_uid: recipeFirebaseUid,
       });
@@ -596,10 +621,10 @@ export class MenuplanMigrationJob implements MigrationJob<FirebaseMenuplanData> 
         event_id: eventId,
         menue_id: menueId,
         product_id: productId,
-        quantity: safeNumber(product.quantity),
+        quantity: safeNumber(product.quantity, 0, MAX_QUANTITY_VALUE),
         unit: product.unit && this.validUnits.has(product.unit) ? product.unit : null,
         plan_mode: planModeToDb(safeNumber(product.planMode)),
-        total_quantity: safeNumber(product.totalQuantity),
+        total_quantity: safeNumber(product.totalQuantity, 0, MAX_QUANTITY_VALUE),
         sort_order: productOrderInMenue.get(productFirebaseUid) ?? 0,
         firebase_uid: productFirebaseUid,
       });
@@ -644,10 +669,10 @@ export class MenuplanMigrationJob implements MigrationJob<FirebaseMenuplanData> 
         event_id: eventId,
         menue_id: menueId,
         material_id: materialId,
-        quantity: safeNumber(material.quantity),
+        quantity: safeNumber(material.quantity, 0, MAX_QUANTITY_VALUE),
         unit: material.unit && this.validUnits.has(material.unit) ? material.unit : null,
         plan_mode: planModeToDb(safeNumber(material.planMode)),
-        total_quantity: safeNumber(material.totalQuantity),
+        total_quantity: safeNumber(material.totalQuantity, 0, MAX_QUANTITY_VALUE),
         sort_order: materialOrderInMenue.get(materialFirebaseUid) ?? 0,
         firebase_uid: materialFirebaseUid,
       });
@@ -841,8 +866,8 @@ export class MenuplanMigrationJob implements MigrationJob<FirebaseMenuplanData> 
         diet_id: dietId,
         intolerance_scope: intoleranceScope,
         intolerance_id: intoleranceId,
-        factor: safeNumber(plan.factor, 1),
-        servings: safeNumber(plan.totalPortions),
+        factor: safeNumber(plan.factor, 1, MAX_FACTOR_VALUE),
+        servings: safeNumber(plan.totalPortions, 0, MAX_QUANTITY_VALUE),
       };
 
       if (itemType === "recipe") row.menue_recipe_id = itemId;

--- a/src/components/Admin/MigrationJobs/RecipeVariantMigrationJob.ts
+++ b/src/components/Admin/MigrationJobs/RecipeVariantMigrationJob.ts
@@ -207,9 +207,32 @@ export class RecipeVariantMigrationJob
   // Alle Varianten-Rezepte aus Firebase lesen
   // ===================================================================== */
   /**
-   * Liest alle Varianten-Rezepte aus Firestore.
-   * Iteriert über `recipes/variants/events/` und liest die Subcollection `recipes/`
-   * jedes Events.
+   * Liest alle Varianten-Rezepte aus Firestore, indem für JEDES bekannte
+   * Event (aus der zuverlässigen Top-Level-`events`-Collection) direkt
+   * dessen `recipes/variants/events/{eventUid}/recipes`-Subcollection
+   * abgefragt wird.
+   *
+   * Bewusst KEINE Auflistung von `recipes/variants/events/` selbst (weder
+   * per normaler Collection-Abfrage noch per `collectionGroup`): Firestore
+   * listet bzw. indexiert Zwischen-Dokumente, die nie selbst mit Feldern
+   * beschrieben wurden und nur implizit durch verschachtelte
+   * Schreibzugriffe entstanden sind ("Ghost-Dokumente"), unzuverlässig.
+   * Manche Events hatten nie ein eigenes
+   * `recipes/variants/events/{eventUid}`-Dokument mit eigenen Feldern,
+   * wodurch deren komplette Varianten-Liste beim Auflisten dieser
+   * Zwischen-Ebene unsichtbar blieb (keine Fehlermeldung, kein Log-Eintrag
+   * - die Datensätze wurden nie zu Kandidaten).
+   *
+   * Eine Subcollection-Abfrage an einem BEKANNTEN Pfad
+   * (`recipes/variants/events/{eventUid}/recipes`) ist davon nicht
+   * betroffen — sie funktioniert unabhängig davon, ob das
+   * Zwischen-Dokument `{eventUid}` selbst je explizit angelegt wurde. Da
+   * die Top-Level-`events`-Collection (anders als das Zwischen-Dokument)
+   * zuverlässig jedes Event enthält — sie wird von jedem anderen
+   * Migrations-Job genauso gelesen (z.B. `EventMigrationJob.ts`) —, liefert
+   * das Iterieren über ALLE bekannten Events + gezielte Subcollection-
+   * Abfrage pro Event garantiert jede Variante, unabhängig vom
+   * Ghost-Dokument-Zustand.
    *
    * Baut ausserdem Lookup-Maps für FK-Auflösungen auf.
    *
@@ -236,15 +259,22 @@ export class RecipeVariantMigrationJob
 
     const records: SourceRecord<FirebaseVariantRecipeData>[] = [];
 
-    // Alle Event-Dokumente unter recipes/variants/events/ lesen
+    // Alle Events aus der zuverlässigen Top-Level-events-Collection lesen
+    // (nicht recipes/variants/events auflisten — siehe Methoden-Doc oben).
     const eventsSnapshot = await getDocs(
-      collection(firebase.firestore, "recipes/variants/events"),
+      collection(firebase.firestore, "events"),
     );
 
     for (const eventDoc of eventsSnapshot.docs) {
       const firebaseEventUid = eventDoc.id;
 
-      // Varianten-Rezepte für dieses Event laden
+      // Meta-Dokument überspringen (analog zu allen anderen event-basierten
+      // Migrations-Jobs)
+      if (firebaseEventUid === "000_allEvents") continue;
+
+      // Varianten-Subcollection dieses Events direkt abfragen — funktioniert
+      // auch, wenn recipes/variants/events/{firebaseEventUid} selbst nie
+      // explizit angelegt wurde.
       const recipesSnapshot = await getDocs(
         collection(
           firebase.firestore,

--- a/src/components/Admin/MigrationJobs/__tests__/migrationJobRegistry.test.ts
+++ b/src/components/Admin/MigrationJobs/__tests__/migrationJobRegistry.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit-Tests für migrationJobRegistry.
+ *
+ * Testet ausschliesslich die FK-Abhängigkeits-Reihenfolge der Registry
+ * (Object-Key-Reihenfolge = Anzeige-/empfohlene Ausführungsreihenfolge in
+ * der Admin-UI, siehe migration.tsx). Fokus: recipeVariants muss vor
+ * menuplan laufen — Menü-Positionen können auf Varianten-Rezepte
+ * verweisen; in falscher Reihenfolge migriert MenuplanMigrationJob diese
+ * Referenzen fälschlich als "[DELETED]" (recipeIdByFirebaseUid enthält zum
+ * Zeitpunkt des Menuplan-Laufs noch keine Varianten-Rezepte).
+ */
+import {getMigrationJobKeys} from "../migrationJobRegistry";
+
+describe("migrationJobRegistry — Reihenfolge", () => {
+  test("recipeVariants steht vor menuplan", () => {
+    const keys = getMigrationJobKeys();
+    const recipeVariantsIndex = keys.indexOf("recipeVariants");
+    const menuplanIndex = keys.indexOf("menuplan");
+
+    expect(recipeVariantsIndex).toBeGreaterThanOrEqual(0);
+    expect(menuplanIndex).toBeGreaterThanOrEqual(0);
+    expect(recipeVariantsIndex).toBeLessThan(menuplanIndex);
+  });
+
+  test("events und recipes stehen vor recipeVariants", () => {
+    const keys = getMigrationJobKeys();
+    const recipeVariantsIndex = keys.indexOf("recipeVariants");
+
+    expect(keys.indexOf("events")).toBeLessThan(recipeVariantsIndex);
+    expect(keys.indexOf("recipes")).toBeLessThan(recipeVariantsIndex);
+  });
+
+  test("events und groupConfig stehen vor menuplan", () => {
+    const keys = getMigrationJobKeys();
+    const menuplanIndex = keys.indexOf("menuplan");
+
+    expect(keys.indexOf("events")).toBeLessThan(menuplanIndex);
+    expect(keys.indexOf("groupConfig")).toBeLessThan(menuplanIndex);
+  });
+
+  test("menuplan steht vor usedRecipes", () => {
+    const keys = getMigrationJobKeys();
+    expect(keys.indexOf("menuplan")).toBeLessThan(keys.indexOf("usedRecipes"));
+  });
+});

--- a/src/components/Admin/MigrationJobs/migrationJobRegistry.ts
+++ b/src/components/Admin/MigrationJobs/migrationJobRegistry.ts
@@ -37,12 +37,16 @@ import {RecipeRatingMigrationJob} from "./RecipeRatingMigrationJob";
  * 4. Produkte (hängt von Abteilungen und Einheiten ab)
  * 5. Standard-Umrechnungen (hängt von Einheiten ab)
  * 6. Produkt-Umrechnungen (hängt von Produkten und Einheiten ab)
- * 7. Rezepte (hängt von Benutzern, Produkten und Materialien ab)
+ * 7. Rezepte, öffentlich/privat (hängt von Benutzern, Produkten und Materialien ab)
  * 8. Events / Köche / Zeitscheiben (hängt von Benutzern ab)
  * 9. Gruppenconfig (hängt von Events ab)
- * 10. Menupläne (hängt von Events, Gruppenconfig, Rezepten, Produkten, Materialien ab)
- * 11. Event-Bilder (hängt von Events ab)
- * 12. Varianten-Rezepte (hängt von Events, Rezepten, Benutzern, Produkten, Materialien ab)
+ * 10. Event-Bilder (hängt von Events ab)
+ * 11. Varianten-Rezepte (hängt von Events, Rezepten öffentlich/privat, Benutzern,
+ *     Produkten, Materialien ab)
+ * 12. Menupläne (hängt von Events, Gruppenconfig, Produkten, Materialien UND
+ *     Varianten-Rezepten ab — Menü-Positionen können auf Varianten-Rezepte
+ *     verweisen; läuft diese Migration vor den Varianten, werden alle
+ *     referenzierten Varianten fälschlich als "[DELETED]" markiert)
  * 13. UsedRecipes (hängt von Events und Menuplänen ab)
  * 14. Einkaufslisten (hängt von Events, Produkten, Materialien, Departments, Units ab)
  * 15. Materiallisten (hängt von Events und Materialien ab)
@@ -65,9 +69,9 @@ export const migrationJobRegistry: Record<string, MigrationJob> = {
   recipeRatings: new RecipeRatingMigrationJob(),
   events: new EventMigrationJob(),
   groupConfig: new GroupConfigMigrationJob(),
-  menuplan: new MenuplanMigrationJob(),
   eventPictures: new EventPictureMigrationJob(),
   recipeVariants: new RecipeVariantMigrationJob(),
+  menuplan: new MenuplanMigrationJob(),
   usedRecipes: new UsedRecipesMigrationJob(),
   shoppingLists: new ShoppingListMigrationJob(),
   materialLists: new MaterialListMigrationJob(),

--- a/src/components/AuthServiceHandler/authServiceHandler.tsx
+++ b/src/components/AuthServiceHandler/authServiceHandler.tsx
@@ -8,6 +8,10 @@ import {ConfirmEmailChangePage} from "./confirmEmailChange";
 import {RecoverEmailPage} from "./recoverEmail";
 import {ResetPasswordPage} from "./resetPassword";
 import {PageTitle} from "../Shared/pageTitle";
+import {
+  initialAuthCallbackHash,
+  initialAuthCallbackSearch,
+} from "../Database/supabaseClient";
 
 import {useCustomStyles} from "../../constants/styles";
 import * as TEXT from "../../constants/text";
@@ -116,10 +120,17 @@ function detectMode(search: string, hash: string): DetectedMode {
  */
 export const AuthServiceHandlerPage = () => {
   const location = useLocation();
-  // Modus einmalig beim ersten Render erfassen, bevor Supabase
-  // die URL-Parameter entfernt (PKCE code cleanup).
+  // Modus einmalig beim ersten Render erfassen. Bevorzugt den Schnappschuss
+  // aus supabaseClient.ts (vor jeglicher Supabase-Verarbeitung eingefroren,
+  // siehe Kommentar dort) — location.hash/.search können zu diesem Zeitpunkt
+  // bereits vom Supabase-Client geleert worden sein. Fallback auf location.*
+  // greift in Tests (MemoryRouter berührt window.location nie) sowie für
+  // den seltenen Fall einer SPA-internen Navigation auf diese Route.
   const {mode, oobCode, errorDescription} = React.useRef(
-    detectMode(location.search, location.hash)
+    detectMode(
+      initialAuthCallbackSearch || location.search,
+      initialAuthCallbackHash || location.hash,
+    )
   ).current;
 
   return (

--- a/src/components/Database/supabaseClient.ts
+++ b/src/components/Database/supabaseClient.ts
@@ -18,6 +18,26 @@ if (!supabaseUrl || !supabaseAnonKey) {
   );
 }
 
+/**
+ * Schnappschuss von Hash/Query der URL, BEVOR der Client unten erstellt wird.
+ *
+ * Grund: Der Client verarbeitet bei aktivem `detectSessionInUrl` (Default)
+ * Auth-Callback-URLs (z.B. `#access_token=...&type=email_change` nach einem
+ * Klick auf einen Bestätigungslink) bereits während seiner asynchronen
+ * Initialisierung und entfernt den Hash danach aus der Adressleiste
+ * (`window.history.replaceState`). Da dieser Vorgang beim Implicit Flow
+ * ohne Server-Roundtrip auskommt, kann er schneller abgeschlossen sein als
+ * React bis zum Mount von `AuthServiceHandlerPage` braucht — eine dortige
+ * Auswertung von `location.hash` käme dann zu spät ("Link nicht erkannt",
+ * obwohl die Session bereits korrekt etabliert wurde). Da JS-Module streng
+ * von oben nach unten ausgewertet werden, läuft dieser Schnappschuss
+ * garantiert vor dem `createClient(...)`-Aufruf unten.
+ */
+export const initialAuthCallbackHash =
+  typeof window !== "undefined" ? window.location.hash : "";
+export const initialAuthCallbackSearch =
+  typeof window !== "undefined" ? window.location.search : "";
+
 /** Globale Supabase-Client-Instanz (Anon Key, RLS aktiv) */
 export const supabase: SupabaseClient = createClient(
   supabaseUrl,

--- a/src/components/Material/materials.tsx
+++ b/src/components/Material/materials.tsx
@@ -656,9 +656,18 @@ const MaterialPage = () => {
         {editMode && state.selectedMaterialUids.length > 0 && (
           <MaterialsQaBulkActions
             selectedCount={state.selectedMaterialUids.length}
+            selectedMaterials={state.materials
+              .filter((material) => state.selectedMaterialUids.includes(material.uid))
+              .map((material) => ({uid: material.uid, name: material.name}))}
             onBulkQaCheck={onBulkQaCheck}
             onMerge={openMergeFromSelection}
             canMerge={state.selectedMaterialUids.length === 2}
+            onRemoveSelected={(uid) =>
+              onSelectionChange(
+                state.selectedMaterialUids.filter((selectedUid) => selectedUid !== uid),
+              )
+            }
+            onClearSelection={() => onSelectionChange([])}
           />
         )}
 
@@ -1226,6 +1235,7 @@ const MaterialsTable = ({
           getRowId={(row) => row.uid}
           pagination
           checkboxSelection={editMode}
+          keepNonExistentRowsSelected
           rowSelectionModel={selectedMaterialUids}
           onRowSelectionModelChange={handleSelectionChange}
           localeText={deDE.components.MuiDataGrid.defaultProps.localeText}

--- a/src/components/Material/materialsQaBulkActions.tsx
+++ b/src/components/Material/materialsQaBulkActions.tsx
@@ -10,6 +10,8 @@ import {
   Button,
   Paper,
   Typography,
+  Box,
+  Chip,
 } from "@mui/material";
 import {
   MergeType as MergeTypeIcon,
@@ -18,21 +20,38 @@ import {
   MATERIALS_SELECTED,
   BULK_QA_CHECK,
   MERGE_MATERIALS,
+  CLEAR_SELECTION,
 } from "../../constants/text/materialQa";
+
+/**
+ * Minimale Material-Information für die Anzeige als Chip in der
+ * Bulk-Aktionen-Toolbar.
+ */
+type SelectedMaterialChip = {
+  uid: string;
+  name: string;
+};
 
 /**
  * Props für die Bulk-Aktionen-Toolbar.
  *
  * @param selectedCount - Anzahl der ausgewählten Materialien
+ * @param selectedMaterials - Ausgewählte Materialien (uid + name) für die Chip-Anzeige,
+ *   unabhängig vom aktuellen Suchfilter
  * @param onBulkQaCheck - Callback für Massen-QA-Markierung
  * @param onMerge - Callback zum Öffnen des Merge-Dialogs
  * @param canMerge - true wenn genau 2 Materialien ausgewählt sind
+ * @param onRemoveSelected - Callback zum gezielten Abwählen eines einzelnen Materials
+ * @param onClearSelection - Callback zum Abwählen aller Materialien
  */
 interface MaterialsQaBulkActionsProps {
   selectedCount: number;
+  selectedMaterials: SelectedMaterialChip[];
   onBulkQaCheck: () => void;
   onMerge: () => void;
   canMerge: boolean;
+  onRemoveSelected: (uid: string) => void;
+  onClearSelection: () => void;
 }
 
 /**
@@ -40,9 +59,12 @@ interface MaterialsQaBulkActionsProps {
  */
 export const MaterialsQaBulkActions = ({
   selectedCount,
+  selectedMaterials,
   onBulkQaCheck,
   onMerge,
   canMerge,
+  onRemoveSelected,
+  onClearSelection,
 }: MaterialsQaBulkActionsProps) => {
   return (
     <Paper
@@ -51,38 +73,68 @@ export const MaterialsQaBulkActions = ({
         padding: 2,
         marginBottom: 2,
         display: "flex",
-        alignItems: "center",
-        gap: 2,
-        flexWrap: "wrap",
+        flexDirection: "column",
+        gap: 1.5,
         backgroundColor: "primary.main",
         color: "primary.contrastText",
       }}
     >
-      <Typography variant="body1" sx={{fontWeight: "bold"}}>
-        {MATERIALS_SELECTED(selectedCount)}
-      </Typography>
+      <Box sx={{display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap"}}>
+        <Typography variant="body1" sx={{fontWeight: "bold"}}>
+          {MATERIALS_SELECTED(selectedCount)}
+        </Typography>
 
-      {/* QA geprüft */}
-      <Button
-        variant="outlined"
-        size="small"
-        sx={{color: "inherit", borderColor: "inherit"}}
-        onClick={onBulkQaCheck}
-      >
-        {BULK_QA_CHECK}
-      </Button>
+        {/* QA geprüft */}
+        <Button
+          variant="outlined"
+          size="small"
+          sx={{color: "inherit", borderColor: "inherit"}}
+          onClick={onBulkQaCheck}
+        >
+          {BULK_QA_CHECK}
+        </Button>
 
-      {/* Zusammenführen (nur bei 2 Materialien) */}
-      <Button
-        variant="outlined"
-        size="small"
-        sx={{color: "inherit", borderColor: "inherit"}}
-        disabled={!canMerge}
-        startIcon={<MergeTypeIcon />}
-        onClick={onMerge}
-      >
-        {MERGE_MATERIALS}
-      </Button>
+        {/* Zusammenführen (nur bei 2 Materialien) */}
+        <Button
+          variant="outlined"
+          size="small"
+          sx={{color: "inherit", borderColor: "inherit"}}
+          disabled={!canMerge}
+          startIcon={<MergeTypeIcon />}
+          onClick={onMerge}
+        >
+          {MERGE_MATERIALS}
+        </Button>
+
+        {/* Alle entfernen */}
+        <Button
+          variant="text"
+          size="small"
+          sx={{color: "inherit"}}
+          onClick={onClearSelection}
+        >
+          {CLEAR_SELECTION}
+        </Button>
+      </Box>
+
+      {/* Ausgewählte Materialien als Chips — bleiben auch bei aktivem Suchfilter
+          sichtbar, damit weggefilterte Auswahlen gezielt abgewählt werden können */}
+      <Box sx={{display: "flex", flexWrap: "wrap", gap: 1}}>
+        {selectedMaterials.map((material) => (
+          <Chip
+            key={material.uid}
+            label={material.name}
+            size="small"
+            onDelete={() => onRemoveSelected(material.uid)}
+            sx={{
+              color: "inherit",
+              borderColor: "inherit",
+              backgroundColor: "primary.dark",
+              "& .MuiChip-deleteIcon": {color: "inherit"},
+            }}
+          />
+        ))}
+      </Box>
     </Paper>
   );
 };

--- a/src/components/Product/products.tsx
+++ b/src/components/Product/products.tsx
@@ -329,12 +329,21 @@ const ProductsPage = () => {
         {editMode && state.selectedProductUids.length > 0 && (
           <ProductsQaBulkActions
             selectedCount={state.selectedProductUids.length}
+            selectedProducts={state.products
+              .filter((product) => state.selectedProductUids.includes(product.uid))
+              .map((product) => ({uid: product.uid, name: product.name}))}
             departments={state.departments}
             onBulkDepartmentChange={hook.onBulkDepartmentChange}
             onBulkDietChange={hook.onBulkDietChange}
             onBulkQaCheck={hook.onBulkQaCheck}
             onMerge={openMergeFromSelection}
             canMerge={state.selectedProductUids.length === 2}
+            onRemoveSelected={(uid) =>
+              hook.onSelectionChange(
+                state.selectedProductUids.filter((selectedUid) => selectedUid !== uid),
+              )
+            }
+            onClearSelection={() => hook.onSelectionChange([])}
           />
         )}
 
@@ -1189,6 +1198,7 @@ const ProductsTable = ({
           getRowId={(row) => row.uid}
           pagination
           checkboxSelection={editMode}
+          keepNonExistentRowsSelected
           rowSelectionModel={selectedProductUids}
           onRowSelectionModelChange={handleSelectionChange}
           localeText={deDE.components.MuiDataGrid.defaultProps.localeText}

--- a/src/components/Product/productsQaBulkActions.tsx
+++ b/src/components/Product/productsQaBulkActions.tsx
@@ -12,6 +12,8 @@ import {
   Typography,
   Menu,
   MenuItem,
+  Box,
+  Chip,
 } from "@mui/material";
 import {
   MergeType as MergeTypeIcon,
@@ -24,28 +26,45 @@ import {
   BULK_CHANGE_DIET,
   BULK_QA_CHECK,
   MERGE_PRODUCTS,
+  CLEAR_SELECTION,
 } from "../../constants/text/productQa";
 import {DIET_TYPES as TEXT_DIET_TYPES} from "../../constants/text";
+
+/**
+ * Minimale Produkt-Information für die Anzeige als Chip in der
+ * Bulk-Aktionen-Toolbar.
+ */
+type SelectedProductChip = {
+  uid: string;
+  name: string;
+};
 
 /**
  * Props für die Bulk-Aktionen-Toolbar.
  *
  * @param selectedCount - Anzahl der ausgewählten Produkte
+ * @param selectedProducts - Ausgewählte Produkte (uid + name) für die Chip-Anzeige,
+ *   unabhängig vom aktuellen Suchfilter
  * @param departments - Verfügbare Abteilungen für die Abteilungsänderung
  * @param onBulkDepartmentChange - Callback für Massen-Abteilungsänderung
  * @param onBulkDietChange - Callback für Massen-Diätänderung
  * @param onBulkQaCheck - Callback für Massen-QA-Markierung
  * @param onMerge - Callback zum Öffnen des Merge-Dialogs
  * @param canMerge - true wenn genau 2 Produkte ausgewählt sind
+ * @param onRemoveSelected - Callback zum gezielten Abwählen eines einzelnen Produkts
+ * @param onClearSelection - Callback zum Abwählen aller Produkte
  */
 interface ProductsQaBulkActionsProps {
   selectedCount: number;
+  selectedProducts: SelectedProductChip[];
   departments: Department[];
   onBulkDepartmentChange: (departmentUid: string, departmentName: string) => void;
   onBulkDietChange: (diet: Diet) => void;
   onBulkQaCheck: () => void;
   onMerge: () => void;
   canMerge: boolean;
+  onRemoveSelected: (uid: string) => void;
+  onClearSelection: () => void;
 }
 
 /**
@@ -53,12 +72,15 @@ interface ProductsQaBulkActionsProps {
  */
 export const ProductsQaBulkActions = ({
   selectedCount,
+  selectedProducts,
   departments,
   onBulkDepartmentChange,
   onBulkDietChange,
   onBulkQaCheck,
   onMerge,
   canMerge,
+  onRemoveSelected,
+  onClearSelection,
 }: ProductsQaBulkActionsProps) => {
   const [deptAnchor, setDeptAnchor] = React.useState<HTMLElement | null>(null);
   const [dietAnchor, setDietAnchor] = React.useState<HTMLElement | null>(null);
@@ -70,105 +92,135 @@ export const ProductsQaBulkActions = ({
         padding: 2,
         marginBottom: 2,
         display: "flex",
-        alignItems: "center",
-        gap: 2,
-        flexWrap: "wrap",
+        flexDirection: "column",
+        gap: 1.5,
         backgroundColor: "primary.main",
         color: "primary.contrastText",
       }}
     >
-      <Typography variant="body1" sx={{fontWeight: "bold"}}>
-        {PRODUCTS_SELECTED(selectedCount)}
-      </Typography>
+      <Box sx={{display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap"}}>
+        <Typography variant="body1" sx={{fontWeight: "bold"}}>
+          {PRODUCTS_SELECTED(selectedCount)}
+        </Typography>
 
-      {/* Abteilung ändern */}
-      <Button
-        variant="outlined"
-        size="small"
-        sx={{color: "inherit", borderColor: "inherit"}}
-        onClick={(event) => setDeptAnchor(event.currentTarget)}
-      >
-        {BULK_CHANGE_DEPARTMENT}
-      </Button>
-      <Menu
-        anchorEl={deptAnchor}
-        open={Boolean(deptAnchor)}
-        onClose={() => setDeptAnchor(null)}
-      >
-        {departments.map((department) => (
+        {/* Abteilung ändern */}
+        <Button
+          variant="outlined"
+          size="small"
+          sx={{color: "inherit", borderColor: "inherit"}}
+          onClick={(event) => setDeptAnchor(event.currentTarget)}
+        >
+          {BULK_CHANGE_DEPARTMENT}
+        </Button>
+        <Menu
+          anchorEl={deptAnchor}
+          open={Boolean(deptAnchor)}
+          onClose={() => setDeptAnchor(null)}
+        >
+          {departments.map((department) => (
+            <MenuItem
+              key={department.uid}
+              onClick={() => {
+                onBulkDepartmentChange(department.uid, department.name);
+                setDeptAnchor(null);
+              }}
+            >
+              {department.name}
+            </MenuItem>
+          ))}
+        </Menu>
+
+        {/* Diät ändern */}
+        <Button
+          variant="outlined"
+          size="small"
+          sx={{color: "inherit", borderColor: "inherit"}}
+          onClick={(event) => setDietAnchor(event.currentTarget)}
+        >
+          {BULK_CHANGE_DIET}
+        </Button>
+        <Menu
+          anchorEl={dietAnchor}
+          open={Boolean(dietAnchor)}
+          onClose={() => setDietAnchor(null)}
+        >
           <MenuItem
-            key={department.uid}
             onClick={() => {
-              onBulkDepartmentChange(department.uid, department.name);
-              setDeptAnchor(null);
+              onBulkDietChange(Diet.Meat);
+              setDietAnchor(null);
             }}
           >
-            {department.name}
+            {TEXT_DIET_TYPES[Diet.Meat]}
           </MenuItem>
+          <MenuItem
+            onClick={() => {
+              onBulkDietChange(Diet.Vegetarian);
+              setDietAnchor(null);
+            }}
+          >
+            {TEXT_DIET_TYPES[Diet.Vegetarian]}
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              onBulkDietChange(Diet.Vegan);
+              setDietAnchor(null);
+            }}
+          >
+            {TEXT_DIET_TYPES[Diet.Vegan]}
+          </MenuItem>
+        </Menu>
+
+        {/* QA geprüft */}
+        <Button
+          variant="outlined"
+          size="small"
+          sx={{color: "inherit", borderColor: "inherit"}}
+          onClick={onBulkQaCheck}
+        >
+          {BULK_QA_CHECK}
+        </Button>
+
+        {/* Zusammenführen (nur bei 2 Produkten) */}
+        <Button
+          variant="outlined"
+          size="small"
+          sx={{color: "inherit", borderColor: "inherit"}}
+          disabled={!canMerge}
+          startIcon={<MergeTypeIcon />}
+          onClick={onMerge}
+        >
+          {MERGE_PRODUCTS}
+        </Button>
+
+        {/* Alle entfernen */}
+        <Button
+          variant="text"
+          size="small"
+          sx={{color: "inherit"}}
+          onClick={onClearSelection}
+        >
+          {CLEAR_SELECTION}
+        </Button>
+      </Box>
+
+      {/* Ausgewählte Produkte als Chips — bleiben auch bei aktivem Suchfilter
+          sichtbar, damit weggefilterte Auswahlen gezielt abgewählt werden können */}
+      <Box sx={{display: "flex", flexWrap: "wrap", gap: 1}}>
+        {selectedProducts.map((product) => (
+          <Chip
+            key={product.uid}
+            label={product.name}
+            size="small"
+            onDelete={() => onRemoveSelected(product.uid)}
+            sx={{
+              color: "inherit",
+              borderColor: "inherit",
+              backgroundColor: "primary.dark",
+              "& .MuiChip-deleteIcon": {color: "inherit"},
+            }}
+          />
         ))}
-      </Menu>
-
-      {/* Diät ändern */}
-      <Button
-        variant="outlined"
-        size="small"
-        sx={{color: "inherit", borderColor: "inherit"}}
-        onClick={(event) => setDietAnchor(event.currentTarget)}
-      >
-        {BULK_CHANGE_DIET}
-      </Button>
-      <Menu
-        anchorEl={dietAnchor}
-        open={Boolean(dietAnchor)}
-        onClose={() => setDietAnchor(null)}
-      >
-        <MenuItem
-          onClick={() => {
-            onBulkDietChange(Diet.Meat);
-            setDietAnchor(null);
-          }}
-        >
-          {TEXT_DIET_TYPES[Diet.Meat]}
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            onBulkDietChange(Diet.Vegetarian);
-            setDietAnchor(null);
-          }}
-        >
-          {TEXT_DIET_TYPES[Diet.Vegetarian]}
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            onBulkDietChange(Diet.Vegan);
-            setDietAnchor(null);
-          }}
-        >
-          {TEXT_DIET_TYPES[Diet.Vegan]}
-        </MenuItem>
-      </Menu>
-
-      {/* QA geprüft */}
-      <Button
-        variant="outlined"
-        size="small"
-        sx={{color: "inherit", borderColor: "inherit"}}
-        onClick={onBulkQaCheck}
-      >
-        {BULK_QA_CHECK}
-      </Button>
-
-      {/* Zusammenführen (nur bei 2 Produkten) */}
-      <Button
-        variant="outlined"
-        size="small"
-        sx={{color: "inherit", borderColor: "inherit"}}
-        disabled={!canMerge}
-        startIcon={<MergeTypeIcon />}
-        onClick={onMerge}
-      >
-        {MERGE_PRODUCTS}
-      </Button>
+      </Box>
     </Paper>
   );
 };

--- a/src/constants/text/materialQa.ts
+++ b/src/constants/text/materialQa.ts
@@ -24,6 +24,7 @@ export const SHOW_ISSUES_ONLY = "Nur mit Problemen";
 export const MATERIALS_SELECTED = (count: number) =>
   `${count} Materialien ausgewählt`;
 export const BULK_QA_CHECK = "Als geprüft markieren";
+export const CLEAR_SELECTION = "Alle entfernen";
 
 /* =====================================================================
 // Material löschen

--- a/src/constants/text/productQa.ts
+++ b/src/constants/text/productQa.ts
@@ -47,6 +47,7 @@ export const PRODUCTS_SELECTED = (count: number) =>
 export const BULK_CHANGE_DEPARTMENT = "Abteilung ändern";
 export const BULK_CHANGE_DIET = "Diät ändern";
 export const BULK_QA_CHECK = "Als geprüft markieren";
+export const CLEAR_SELECTION = "Alle entfernen";
 
 /* =====================================================================
 // Synonyme

--- a/supabase/docker-compose.prod.yml
+++ b/supabase/docker-compose.prod.yml
@@ -167,7 +167,12 @@ services:
       # Uncomment to bypass nonce check in ID Token flow. Commonly set to true when using Google Sign In on mobile.
       # GOTRUE_EXTERNAL_SKIP_NONCE_CHECK: "true"
 
-      # GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED: "true"
+      # GoTrue-Default für dieses Setting ist "true" (auch wenn hier
+      # auskommentiert) — daher explizit auf "false" gesetzt. Nur die neue
+      # E-Mail-Adresse muss bestätigt werden, nicht zusätzlich die alte
+      # (Frontend/ConfirmEmailChangePage ist ohnehin nur für Single-Confirm
+      # gebaut; Zwei-Schritt-Bestätigung würde als "Link nicht erkannt" enden).
+      GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED: "false"
       # GOTRUE_SMTP_MAX_FREQUENCY: 1s
       GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL}
       GOTRUE_SMTP_HOST: ${SMTP_HOST}

--- a/supabase/docker-compose.prod.yml
+++ b/supabase/docker-compose.prod.yml
@@ -182,6 +182,10 @@ services:
       GOTRUE_MAILER_TEMPLATES_RECOVERY: http://supabase-mail-templates-prod/recovery.html
       GOTRUE_MAILER_TEMPLATES_EMAIL_CHANGE: http://supabase-mail-templates-prod/email_change.html
       GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: ${MAILER_URLPATHS_EMAIL_CHANGE}
+      # Deutsche Betreffzeilen (GoTrue-Default ist Englisch, unabhängig vom HTML-Template)
+      GOTRUE_MAILER_SUBJECTS_CONFIRMATION: "E-Mail-Adresse bestätigen"
+      GOTRUE_MAILER_SUBJECTS_RECOVERY: "Passwort zurücksetzen"
+      GOTRUE_MAILER_SUBJECTS_EMAIL_CHANGE: "Neue E-Mail-Adresse bestätigen"
 
       GOTRUE_EXTERNAL_PHONE_ENABLED: ${ENABLE_PHONE_SIGNUP}
       GOTRUE_SMS_AUTOCONFIRM: ${ENABLE_PHONE_AUTOCONFIRM}

--- a/supabase/docker-compose.yml
+++ b/supabase/docker-compose.yml
@@ -167,7 +167,12 @@ services:
       # Uncomment to bypass nonce check in ID Token flow. Commonly set to true when using Google Sign In on mobile.
       # GOTRUE_EXTERNAL_SKIP_NONCE_CHECK: "true"
 
-      # GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED: "true"
+      # GoTrue-Default für dieses Setting ist "true" (auch wenn hier
+      # auskommentiert) — daher explizit auf "false" gesetzt. Nur die neue
+      # E-Mail-Adresse muss bestätigt werden, nicht zusätzlich die alte
+      # (Frontend/ConfirmEmailChangePage ist ohnehin nur für Single-Confirm
+      # gebaut; Zwei-Schritt-Bestätigung würde als "Link nicht erkannt" enden).
+      GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED: "false"
       # GOTRUE_SMTP_MAX_FREQUENCY: 1s
       GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL}
       GOTRUE_SMTP_HOST: ${SMTP_HOST}

--- a/supabase/docker-compose.yml
+++ b/supabase/docker-compose.yml
@@ -182,6 +182,10 @@ services:
       GOTRUE_MAILER_TEMPLATES_RECOVERY: http://supabase-mail-templates-test/recovery.html
       GOTRUE_MAILER_TEMPLATES_EMAIL_CHANGE: http://supabase-mail-templates-test/email_change.html
       GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: ${MAILER_URLPATHS_EMAIL_CHANGE}
+      # Deutsche Betreffzeilen (GoTrue-Default ist Englisch, unabhängig vom HTML-Template)
+      GOTRUE_MAILER_SUBJECTS_CONFIRMATION: "E-Mail-Adresse bestätigen"
+      GOTRUE_MAILER_SUBJECTS_RECOVERY: "Passwort zurücksetzen"
+      GOTRUE_MAILER_SUBJECTS_EMAIL_CHANGE: "Neue E-Mail-Adresse bestätigen"
 
       GOTRUE_EXTERNAL_PHONE_ENABLED: ${ENABLE_PHONE_SIGNUP}
       GOTRUE_SMS_AUTOCONFIRM: ${ENABLE_PHONE_AUTOCONFIRM}


### PR DESCRIPTION
Beim wechsel der E-Mailadressen mussten beide Bestätigungslinks (neue und alte Adresse) bestätigt werden. Etwas zu heftig. Rückbau.
Zusätzliche Enhancement bei der Übersicht der Produkte und Materialien